### PR TITLE
decompose: push each child as it finishes, not all-at-end

### DIFF
--- a/FUTURE.md
+++ b/FUTURE.md
@@ -1,0 +1,80 @@
+# Scout — Next Arc
+
+Scout-the-artifact-pipeline is mature. The next level is Scout-the-system-you-live-in. Three axes, each weak today, each compounding when stronger.
+
+## The triangle
+
+- **Corpus** — Atlas as a knowledge graph, not a flat list of cards.
+- **Capture** — sub-10s path from "I have a question" to Scout is running.
+- **Active** — Scout runs without being asked.
+
+Each axis amplifies the others:
+- Capture without Corpus = more islands.
+- Corpus without Capture = a pretty graveyard.
+- Active without either = noise.
+
+## Corpus
+
+Today: flat list of `research/<date>-<slug>/` cards. Every run is an island.
+
+- Full-text search across Atlas (Lunr / Pagefind, static-site friendly).
+- Tag pages: `/tags/<tag>/` aggregating runs.
+- `related:` frontmatter — pre-write pass greps prior runs by tag/topic, links 1–3 most relevant.
+- RSS feed of new research.
+- Graph view (long-term): nodes = runs, edges = shared tags / shared citations.
+
+## Capture
+
+Today: only path is browser → github.com → New Issue → fill template. Desk-only, ~60s. Most questions arrive on a phone.
+
+| Surface | Trigger | Notes |
+|---|---|---|
+| iOS share-sheet | Share URL/text from any app | Highest leverage. iOS Shortcut → GitHub API. |
+| Email-to-Issue | Forward to `scout@<domain>` | Subject = topic, body = steering. Cloudflare Email Routing → webhook → `gh issue create`. |
+| Voice / Siri | Spoken topic | Same plumbing as share-sheet, dictation input. |
+| Telegram/Slack bot | DM a topic | Reuse Slack remote-control plumbing. |
+| Backlog drain | `scout-backlog.md` or `backlog` label | Decouples having an idea from running it. Scout pulls when idle. |
+| Bookmarklet | One click on any page | Desk-version of share-sheet. |
+| Atlas follow-up button | Bottom of every artifact | Pre-fills `extends: <prior-artifact>`. |
+
+Every surface ends in `gh issue create --template research.yml`. Build share-sheet first; rest are variations.
+
+Second-order effects:
+- Capture without friction is a usage-pattern flip. Runs become opportunistic, not deliberate. Volume goes up 5–10×.
+- Cheap capture changes *what* gets researched — small curiosities now worth queuing.
+
+## Active
+
+Today: pure on-demand. Scout never runs unless you ask.
+
+| Flavor | Trigger | Cost | Example |
+|---|---|---|---|
+| **Watch** | Cron over published artifact's ledger | Cheap (ledger-only) | Re-fetch each cited URL, diff against stored `quote`, comment if drift. |
+| **Drain** | Idle-time backlog pull | Cheap | Overnight: Scout works through queued curiosities. |
+| **React** | External event hook | Per-integration | New repo release / arXiv paper / RSS item → Scout opens its own Issue. |
+| **Subscribe** | Cron over standing topic | Expensive (full re-run) | Weekly "best self-hosted LLM router" — only publish if conclusions shifted. |
+| **Curate** | Self-reflective cron over Atlas | Medium | "Run #12 and #34 disagree on X — reconcile?" or "8 dead URLs across 23 runs." |
+
+Distinctions:
+- Watch ≠ Subscribe. Watch checks if *sources* moved. Subscribe checks if *the answer* moved.
+- React ≠ Drain. React is exogenous (world changed). Drain is endogenous (you queued earlier).
+- Curate only becomes interesting once Atlas has 30+ entries.
+
+## Build order
+
+1. **Capture: iOS share-sheet** — biggest UX delta per hour spent.
+2. **Corpus: search + `related:` cross-links** — turns Atlas from list into graph.
+3. **Active: Watch** — cheapest active flavor, catches link rot and quote drift everywhere.
+4. **Capture: email + backlog drain** — closes the queue loop.
+5. **Corpus: tags + RSS** — discoverability and ambient awareness.
+6. **Active: React** — per-source integration, build as needed.
+7. **Active: Subscribe + Curate** — long-tail; only worth it once corpus is rich.
+
+## Out of scope here
+
+Tracked elsewhere or deferred:
+
+- Rigor bolt-ons (multi-persona critique, MCP search backend, claim-level quote verification) — real, but second-order vs the triangle. See survey: `atlas/research/2026-04-21-survey-of-research-agents-...`.
+- Security hardening (egress allowlist, read-only root, output validator) — see `TODO.md`.
+- Multimodal output (charts, maps, timelines in body) — orthogonal axis.
+- Operational hardening (budget caps, cancellation, retries, cost dashboard) — surfaces once capture lifts volume.

--- a/scripts/lib-publish.sh
+++ b/scripts/lib-publish.sh
@@ -69,3 +69,46 @@ pr_fallback() {
       "Atlas \`main\` moved during this run. Branch pushed: \`$branch\`. Open PR: $url"
   fi
 }
+
+# publish_path <commit-msg> <stage-target> <fallback-branch>
+# Stages <stage-target> (a path or "."), commits, pushes to origin/main with
+# rebase+retry; on rebase conflict or 3 exhausted retries, falls back to
+# pushing to <fallback-branch> and prints a compare URL.
+# Preconditions: cwd is the atlas-checkout git repo. ATLAS_REPO env may be set
+# (used in PR-fallback compare URL). GIT_AUTHOR_{NAME,EMAIL} envs control the
+# commit identity (Scout fallback if unset).
+# Returns: 0 on success (main or PR-fallback branch),
+#          2 nothing staged (caller decides whether that's an error),
+#          3 hard failure (auth/network/etc).
+publish_path() {
+  local msg="$1" target="$2" branch="$3"
+
+  git add -- "$target"
+  if git diff --cached --quiet; then
+    return 2
+  fi
+
+  git -c user.name="${GIT_AUTHOR_NAME:-Scout}" \
+      -c user.email="${GIT_AUTHOR_EMAIL:-scout@users.noreply.github.com}" \
+    commit -m "$msg"
+
+  local rc=0
+  rc=0; try_push || rc=$?
+  if [ "$rc" -eq 2 ]; then return 3; fi
+  if [ "$rc" -eq 1 ]; then
+    local i
+    for i in 1 2 3; do
+      if ! rebase_onto_remote; then
+        pr_fallback "$branch" "${ATLAS_REPO:-}"
+        return 0
+      fi
+      rc=0; try_push || rc=$?
+      [ "$rc" -eq 0 ] && return 0
+      [ "$rc" -eq 2 ] && return 3
+      sleep $((2 ** (i - 1)))
+    done
+    pr_fallback "$branch" "${ATLAS_REPO:-}"
+    return 0
+  fi
+  return 0
+}

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -19,39 +19,16 @@ if [ ! -d "$ATLAS_DIR/.git" ]; then
 fi
 
 cd "$ATLAS_DIR"
-git add .
 
-if git diff --cached --quiet; then
-  echo "publish.sh: nothing to commit (Scout may have failed to write an artifact)." >&2
-  exit 2
-fi
-
-# Commit as the triggering GitHub user. Workflow sets GIT_{AUTHOR,COMMITTER}_{NAME,EMAIL}
-# from ${{ github.actor }} / ${{ github.actor_id }}. Fall back to Scout if run outside CI.
-git -c user.name="${GIT_AUTHOR_NAME:-Scout}" \
-    -c user.email="${GIT_AUTHOR_EMAIL:-scout@users.noreply.github.com}" \
-  commit -m "research: ${DATE} ${SLUG}" -m "Topic: ${TOPIC}"
-
+COMMIT_MSG="$(printf 'research: %s %s\n\nTopic: %s' "$DATE" "$SLUG" "$TOPIC")"
 BRANCH="scout/${DATE}-${SLUG}"
 
-rc=0; try_push || rc=$?
-if [ "$rc" -eq 2 ]; then exit 1; fi
-if [ "$rc" -eq 1 ]; then
-  for i in 1 2 3; do
-    if ! rebase_onto_remote; then
-      pr_fallback "$BRANCH" "$ATLAS_REPO"
-      exit 0
-    fi
-    rc=0; try_push || rc=$?
-    [ "$rc" -eq 0 ] && break
-    [ "$rc" -eq 2 ] && exit 1
-    sleep $((2 ** (i - 1)))
-  done
-  if [ "$rc" -ne 0 ]; then
-    pr_fallback "$BRANCH" "$ATLAS_REPO"
-    exit 0
-  fi
-fi
+rc=0; publish_path "$COMMIT_MSG" "." "$BRANCH" || rc=$?
+case "$rc" in
+  0) ;;
+  2) echo "publish.sh: nothing to commit (Scout may have failed to write an artifact)." >&2; exit 2 ;;
+  *) exit 1 ;;
+esac
 
 # Derive the Pages URL from ATLAS_REPO (git@github.com-atlas:<owner>/<repo>.git).
 atlas_slug="${ATLAS_REPO#*:}"; atlas_slug="${atlas_slug%.git}"

--- a/scripts/run-decompose.sh
+++ b/scripts/run-decompose.sh
@@ -34,6 +34,40 @@ mkdir -p "$PARENT_DIR"
 if [ -f "$SCOUT_DIR/scripts/slug.sh" ]; then
   source "$SCOUT_DIR/scripts/slug.sh"
 fi
+
+# Push helpers — used to commit+push each successful child immediately so a
+# mid-expedition crash doesn't lose the work of children that already finished.
+# Sourced defensively (matches slug.sh pattern): tests that stub SCOUT_DIR
+# without copying lib-publish.sh fall back to a no-op _publish_child.
+if [ -f "$SCOUT_DIR/scripts/lib-publish.sh" ]; then
+  # shellcheck source=scripts/lib-publish.sh
+  source "$SCOUT_DIR/scripts/lib-publish.sh"
+fi
+
+PARENT_BASE="$(basename "$PARENT_DIR")"
+PARENT_SLUG="${PARENT_BASE#"$DATE"-}"
+PARENT_BRANCH="scout/${DATE}-${PARENT_SLUG}"
+
+# Push a single child's folder to Atlas main. No-op if publish_path isn't
+# available (test environments) or atlas-checkout isn't a git repo (standalone
+# decompose runs without a real Atlas). Per-child push failure is non-fatal:
+# the parent's final publish.sh sweep will retry with everything still on disk.
+_publish_child() {
+  local child_dir="$1" cslug="$2"
+  declare -F publish_path >/dev/null || return 0
+  local atlas_root rel_path rc=0
+  atlas_root="$(cd "$child_dir" 2>/dev/null && git rev-parse --show-toplevel 2>/dev/null)" || return 0
+  [ -n "$atlas_root" ] || return 0
+  rel_path="${child_dir#"$atlas_root"/}"
+  (
+    cd "$atlas_root"
+    publish_path "research: ${DATE} ${PARENT_SLUG}/${cslug}" "$rel_path" "$PARENT_BRANCH"
+  ) || rc=$?
+  if [ "$rc" -ne 0 ] && [ "$rc" -ne 2 ]; then
+    echo "[run-decompose] per-child push failed for $cslug (rc=$rc); deferring to final publish" >&2
+  fi
+  return 0
+}
 _simple_slug() {
   printf '%s' "$1" | tr '[:upper:]' '[:lower:]' \
     | sed -e 's/[^a-z0-9]/-/g' -e 's/--*/-/g' -e 's/^-//' -e 's/-$//' \
@@ -155,6 +189,7 @@ for entry in "${CHILDREN[@]}"; do
       set -e
       if [ "$rc" -eq 0 ] && _child_is_success "$child_dir"; then
         child_status="success"
+        _publish_child "$child_dir" "$cslug"
       elif [ "$rc" -eq 124 ]; then
         _write_placeholder "$child_dir" "$cdepth" "hard timeout"
         child_status="failed_hard_timeout"
@@ -314,10 +349,11 @@ if [ -n "$PARENT_FILE" ]; then
   _set_field "$PARENT_FILE" reading_time_min "$TOT_READING"
 fi
 
-# --- Publish: one commit covers parent synthesis + every child subfolder. ---
+# --- Publish: parent synthesis + manifest + any failure placeholders. ---
+# Children that succeeded were already pushed individually inside the loop; this
+# final publish picks up whatever's left (synthesis index.md, manifest.json,
+# placeholders for failed/skipped children).
 SOFT_LOG="$(mktemp -t scout-decompose-softfail.XXXXXX.log)"
-PARENT_BASE="$(basename "$PARENT_DIR")"
-PARENT_SLUG="${PARENT_BASE#"$DATE"-}"
 
 (
   cd "$SCOUT_DIR"

--- a/tests/test_run_decompose_per_child_push.sh
+++ b/tests/test_run_decompose_per_child_push.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Verifies run-decompose.sh pushes each successful child to the Atlas remote
+# BEFORE running the next child, so a mid-expedition crash doesn't lose the
+# work of children that already finished.
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PASS=0; FAIL=0
+declare -a FAIL_MSGS
+pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+fail() { FAIL_MSGS+=("$1"); FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
+
+echo "Testing run_decompose_per_child_push.sh..."
+
+TMP=$(mktemp -d)
+ATLAS_REMOTE="$TMP/atlas-remote.git"
+ATLAS_DIR="$TMP/scout/atlas-checkout"
+PARENT_DIR="$ATLAS_DIR/research/2026-04-26-test"
+
+mkdir -p "$TMP/scout/scripts" "$TMP/scout/skills/scout" "$TMP/bin"
+
+# --- Fake Atlas remote -------------------------------------------------------
+git -c init.defaultBranch=main init -q "$TMP/seed"
+git -C "$TMP/seed" -c user.name=seed -c user.email=s@s commit --allow-empty -q -m "init"
+git clone -q --bare "$TMP/seed" "$ATLAS_REMOTE"
+rm -rf "$TMP/seed"
+git clone -q "$ATLAS_REMOTE" "$ATLAS_DIR"
+
+# --- Stub run.sh: snapshots remote state, then writes a successful child ---
+cat > "$TMP/scout/scripts/run.sh" <<STUB
+#!/usr/bin/env bash
+mkdir -p "\$RESEARCH_DIR"
+# Snapshot what's on remote main right now, indexed by topic.
+git --git-dir="$ATLAS_REMOTE" log main --format=%s > "$TMP/remote-at-\$TOPIC.txt"
+cat > "\$RESEARCH_DIR/index.md" <<MD
+---
+title: \$TOPIC
+status: success
+citations: 5
+reading_time_min: 2
+cost_usd: 1.50
+duration_sec: 600
+summary: stub
+---
+stub child body for \$TOPIC
+MD
+STUB
+chmod +x "$TMP/scout/scripts/run.sh"
+
+# --- Real lib-publish.sh + run-decompose.sh + slug.sh + lib-issue-parse.sh ---
+cp "$REPO_ROOT/scripts/lib-publish.sh"      "$TMP/scout/scripts/"
+cp "$REPO_ROOT/scripts/lib-issue-parse.sh"  "$TMP/scout/scripts/"
+cp "$REPO_ROOT/scripts/slug.sh"             "$TMP/scout/scripts/"
+cp "$REPO_ROOT/scripts/run-decompose.sh"    "$TMP/scout/scripts/"
+# Real publish.sh handles the final parent commit.
+cp "$REPO_ROOT/scripts/publish.sh"          "$TMP/scout/scripts/"
+echo "stub synthesis skill" > "$TMP/scout/skills/scout/synthesis.md"
+
+# --- Stub claude (synthesis pass) ---
+cat > "$TMP/bin/claude" <<STUB
+#!/usr/bin/env bash
+PD="$PARENT_DIR"
+cat > "\$PD/index.md" <<EOF
+---
+layout: expedition
+title: Test parent
+synthesis: true
+---
+synthesis prose
+EOF
+echo '{"result":"ok","total_cost_usd":0.42,"duration_ms":15000}'
+STUB
+chmod +x "$TMP/bin/claude"
+
+# --- Run the orchestrator ---
+env PATH="$TMP/bin:$PATH" \
+    PARENT_DIR="$PARENT_DIR" \
+    PARENT_TOPIC="Parent topic" \
+    PARENT_FORMAT="md" \
+    DATE=2026-04-26 \
+    SUB_TOPICS_TSV=$'A|standard|reasonA|true\nB|standard|reasonB|true' \
+    SCOUT_DIR="$TMP/scout" \
+    ATLAS_REPO="$ATLAS_REMOTE" \
+    GH_TOKEN="" GH_REPO="" ISSUE_NUMBER="" \
+    GIT_AUTHOR_NAME="tester" GIT_AUTHOR_EMAIL="t@t" \
+    bash "$TMP/scout/scripts/run-decompose.sh" >"$TMP/run.log" 2>&1
+RC=$?
+
+[ "$RC" = "0" ] && pass "run-decompose exits 0" \
+                || fail "run-decompose exit=$RC, log:\n$(cat "$TMP/run.log")"
+
+# --- Per-child push happens BEFORE next child runs ---
+# When A's stub ran, remote had only the init commit.
+[ -f "$TMP/remote-at-A.txt" ] \
+  && [ "$(grep -c . "$TMP/remote-at-A.txt")" = "1" ] \
+  && grep -q '^init$' "$TMP/remote-at-A.txt" \
+  && pass "child A: remote had only init at start" \
+  || fail "child A: remote state at start unexpected:\n$(cat "$TMP/remote-at-A.txt" 2>/dev/null)"
+
+# When B's stub ran, remote ALREADY had A's commit pushed.
+[ -f "$TMP/remote-at-B.txt" ] \
+  && grep -q 'research: 2026-04-26 test/a' "$TMP/remote-at-B.txt" \
+  && pass "child B: remote already had child A's commit before B started" \
+  || fail "child B: remote did not have child A's commit yet:\n$(cat "$TMP/remote-at-B.txt" 2>/dev/null)"
+
+# --- Final remote state: 3 research commits + init = 4, in correct order ---
+mapfile -t MAIN_LOG < <(git --git-dir="$ATLAS_REMOTE" log main --format=%s)
+[ "${#MAIN_LOG[@]}" -eq 4 ] \
+  && pass "remote main has 4 commits (init + 2 children + parent)" \
+  || fail "remote main commit count: ${#MAIN_LOG[@]} — log:\n$(printf '%s\n' "${MAIN_LOG[@]}")"
+
+# Top of log = parent synthesis commit
+[ "${MAIN_LOG[0]}" = "research: 2026-04-26 test" ] \
+  && pass "top commit is parent synthesis" \
+  || fail "top commit was '${MAIN_LOG[0]}'"
+
+# Children land as separate commits with parent-slug/child-slug subject
+git --git-dir="$ATLAS_REMOTE" log main --format=%s | grep -qx 'research: 2026-04-26 test/a' \
+  && pass "child A has its own commit on remote" \
+  || fail "child A commit not found in:\n$(printf '%s\n' "${MAIN_LOG[@]}")"
+git --git-dir="$ATLAS_REMOTE" log main --format=%s | grep -qx 'research: 2026-04-26 test/b' \
+  && pass "child B has its own commit on remote" \
+  || fail "child B commit not found in:\n$(printf '%s\n' "${MAIN_LOG[@]}")"
+
+# --- All three artifacts present on remote main ---
+git --git-dir="$ATLAS_REMOTE" show "main:research/2026-04-26-test/a/index.md" >/dev/null 2>&1 \
+  && pass "child A index.md is on remote main" || fail "child A index.md missing on remote"
+git --git-dir="$ATLAS_REMOTE" show "main:research/2026-04-26-test/b/index.md" >/dev/null 2>&1 \
+  && pass "child B index.md is on remote main" || fail "child B index.md missing on remote"
+git --git-dir="$ATLAS_REMOTE" show "main:research/2026-04-26-test/index.md" >/dev/null 2>&1 \
+  && pass "parent index.md is on remote main" || fail "parent index.md missing on remote"
+
+rm -rf "$TMP"
+
+echo
+echo "Results: $PASS passed, $FAIL failed"
+if [ $FAIL -gt 0 ]; then
+  printf '  %s\n' "${FAIL_MSGS[@]}"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- A 4h expedition currently lands as one commit at the very end. When the runner hits the timeout (or anything else kills the process mid-run), every completed child is lost.
- Each successful child is now committed + pushed to Atlas main immediately after `run.sh` returns, so a mid-run kill leaves finished work durable.
- The next run resumes for free: `--depth=1` clone pulls the already-pushed children, `_child_is_success` skips them, only missing/failed children re-run.

## Changes

- `lib-publish.sh`: factor commit+push+rebase+retry+PR-fallback into `publish_path()` (path + fallback branch).
- `publish.sh`: parent-level final push now uses `publish_path`. Behavior unchanged.
- `run-decompose.sh`: `_publish_child` called after each successful child. Per-child push failure is non-fatal — the final publish sweep retries anything still on disk.
- All children share the same fallback branch (`scout/<date>-<parent-slug>`) so a non-ff doesn't fragment one expedition across N branches.

## Test plan

- [x] New test: `tests/test_run_decompose_per_child_push.sh` — fake bare remote, asserts each child is pushed before the next child starts and that the remote ends up with init + child A + child B + parent (4 commits).
- [x] Full suite green (11 test files).
- [ ] Real run: trigger an expedition via issue and confirm Atlas main shows N+1 commits per expedition.
- [ ] Resume: kill an expedition mid-run (or let it timeout), re-trigger, confirm the previously-pushed children are skipped on the second run.